### PR TITLE
Remove `qsub` attributes

### DIFF
--- a/machines/theta
+++ b/machines/theta
@@ -17,6 +17,5 @@ else
   NB_RUN_CMD="qsub -n $nb_nnodes
                    -q $nb_queue
                    -t $nb_time
-                   -A $nb_project
-                   --attrs mcdram=flat:numa=quad"
+                   -A $nb_project"
 fi


### PR DESCRIPTION
Removed the line which slows down 2x for 512 MPI ranks with Sashi's case.